### PR TITLE
Handle missing database URLs with SQLite defaults

### DIFF
--- a/api/db.py
+++ b/api/db.py
@@ -3,15 +3,17 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from .models import Base
 
-DATABASE_URL = os.getenv("DATABASE_URL")
-POLICY_DATABASE_URL = os.getenv("POLICY_DATABASE_URL")
+# URLs de conexão dos bancos de dados. Se não forem fornecidas via variáveis
+# de ambiente, usa-se SQLite local para permitir que a aplicação inicialize.
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./data.db")
+POLICY_DATABASE_URL = os.getenv("POLICY_DATABASE_URL", "sqlite:///./policy.db")
 
 # Engine de dados (Protheus_Producao)
 data_engine = create_engine(
     DATABASE_URL,
     pool_pre_ping=True,
     pool_recycle=3600,
-    connect_args={"autocommit": True, "timeout": int(os.getenv("DB_CONNECTION_TIMEOUT", "300"))}
+    connect_args={"autocommit": True, "timeout": int(os.getenv("DB_CONNECTION_TIMEOUT", "300"))},
 )
 
 # Engine de políticas/logs (BISOBEL)
@@ -19,7 +21,7 @@ policy_engine = create_engine(
     POLICY_DATABASE_URL,
     pool_pre_ping=True,
     pool_recycle=3600,
-    connect_args={"autocommit": True, "timeout": int(os.getenv("DB_CONNECTION_TIMEOUT", "300"))}
+    connect_args={"autocommit": True, "timeout": int(os.getenv("DB_CONNECTION_TIMEOUT", "300"))},
 )
 
 PolicySessionLocal = sessionmaker(bind=policy_engine, autoflush=False, autocommit=False)

--- a/fixer.sh
+++ b/fixer.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Configura variáveis de ambiente padrão para executar a Suprema API
+
+export DATABASE_URL=${DATABASE_URL:-sqlite:///./data.db}
+export POLICY_DATABASE_URL=${POLICY_DATABASE_URL:-sqlite:///./policy.db}
+
+echo "DATABASE_URL=$DATABASE_URL"
+echo "POLICY_DATABASE_URL=$POLICY_DATABASE_URL"


### PR DESCRIPTION
## Summary
- prevent startup crash when DATABASE_URL vars are absent by defaulting to local SQLite files
- add fixer script that sets default database URLs for quick setup

## Testing
- `python -m uvicorn api.main:app --host 0.0.0.0 --port 8508 --log-level info` (started and shut down)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1d9aaae28832c98eef447a867f55e